### PR TITLE
chore(config): modify default config of redis&mongo for dev with docker

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -94,7 +94,7 @@ module.exports = appInfo => {
     client: {
       host: process.env.EGG_REDIS_HOST || '127.0.0.1',
       port: process.env.EGG_REDIS_PORT || 6379,
-      password: process.env.EGG_REDIS_PASSWORD || '',
+      password: process.env.EGG_REDIS_PASSWORD || 'egg_cnode',
       db: process.env.EGG_REDIS_DB || '0',
     },
   };
@@ -103,7 +103,7 @@ module.exports = appInfo => {
    * @see http://mongodb.github.io/node-mongodb-native/2.2/api/Db.html#createCollection
    */
   config.mongoose = {
-    url: process.env.EGG_MONGODB_URL || 'mongodb://127.0.0.1:27017/egg_cnode',
+    url: process.env.EGG_MONGODB_URL || 'mongodb://egg_cnode:egg_cnode@127.0.0.1:27017/egg_cnode',
     options: {
       server: { poolSize: 20 },
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
default config

##### Description of change
<!-- Provide a description of the change below this comment. -->
The redis and mongodb environment for local dev built with the latest `docker-compose.dev.yml` require authentication, so add the default credentials into  the config.
